### PR TITLE
adding composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "bmbrands/moodle-local_welcome",
+    "description": "This plugin sends a configurable welcome message to new users and notifies the admin",
+    "type": "moodle-local",
+    "require": {
+        "composer/installers": "*"
+    },
+    "extra": {
+      "installer-name": "welcome"
+    }
+}


### PR DESCRIPTION
Hello,

this adds the composer.json file so people can deploy your plugin
using the composer tool (https://getcomposer.org/).
Although it is not a Moodle standard or recommendation (yet), composer is largely used
and accepted tool in the PHP community.
If you have any questions, please take a look at the following links:

http://www.phptherightway.com/#composer_and_packagist
https://moodle.org/mod/forum/discuss.php?d=275466
https://tracker.moodle.org/browse/MDL-48114
https://moodle.org/mod/forum/discuss.php?d=312215

I've made some pull requests to plugins that I use and like
and that have their source on github and until this point
12 plugins have merged (including your bootstrap theme =),
19 are pending (including this one and your elegance theme =)
and only 1 delayed until a definitive position from Moodle HQ.

Kind regards,
Daniel
