### PR TITLE
Move Events 1 API deprecated handlers to API v2 (classes) M31+

### DIFF
--- a/classes/message.php
+++ b/classes/message.php
@@ -1,0 +1,132 @@
+<?php
+// This file is part of the Local welcome plugin
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    local_welcome
+ * @copyright  2015 Bas Brands
+ * @author     Bas Brands, basbrands.nl
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_welcome;
+global $CFG;
+require_once($CFG->dirroot . '/user/profile/lib.php');
+require_once($CFG->dirroot . '/user/lib.php');
+
+class message {
+
+    public $defaultfields;
+    public $welcomefields;
+    public $welcomevalues;
+    public $customfields;
+
+    public function __construct() {
+        $this->defaultfields = $this->get_default_fields();
+        $this->welcomefields = $this->get_welcome_fields();
+        $this->welcomevalues = $this->get_welcome_values();
+        $this->customfields = $this->get_custom_fields();
+    }
+
+
+    private function get_default_fields() {
+        $defaultfields = array('username', 'fullname', 'firstname', 'lastname', 'email',
+            'address', 'phone1', 'phone2', 'icq', 'skype', 'yahoo', 'aim', 'msn', 'department',
+            'institution', 'interests', 'idnumber', 'lang', 'timezone', 'description',
+            'city', 'url', 'country'
+        );
+
+        return $defaultfields;
+    }
+
+    private function get_welcome_fields() {
+        $welcomefields = array('sitelink', 'sitename', 'resetpasswordlink');
+
+        return $welcomefields;
+    }
+
+    private function get_custom_fields() {
+        $customfields = profile_get_custom_fields(true);
+        $returnfields = array();
+        foreach ($customfields as $field) {
+            $returnfields[] = $field->shortname;
+        }
+        return $returnfields;
+    }
+
+    public function get_user_default_values($user) {
+        $values = array();
+        foreach ($this->defaultfields as $field) {
+            if (isset($user->$field)) {
+                $values[$field] = $user->$field;
+            } else {
+                $values[$field] = '';
+            }
+            if ($field == 'fullname') {
+                $values[$field] = fullname($user);
+            }
+            if (!empty($user->$field) && $field == 'country') {
+                $values[$field]  = get_string($user->country, 'countries');
+            } 
+        }
+        return $values;
+    }
+
+    public function get_user_custom_values($user) {
+        $userinfo = profile_user_record($user->id);
+        $values = array();
+        foreach($this->customfields as $field) {
+            $fieldname = $field;
+            if (isset($userinfo->$fieldname)) {
+                $values[$field] = $userinfo->$fieldname;
+            } else {
+                $values[$field] = '';
+            }
+        }
+        return $values;
+    }
+
+    public function get_welcome_values() {
+        global $SITE;
+
+        $values = array();
+        $sitelink = \html_writer::link(new \moodle_url('/'), $SITE->fullname);
+        $sitename = $SITE->fullname;
+        $resetpasswordlink = \html_writer::link(new \moodle_url('/login/forgot_password.php'), get_string('resetpass', 'local_welcome'));
+        foreach ($this->welcomefields as $field) {
+            $values[$field]= $$field;
+        }
+        return $values;
+    }
+
+    public function replace_values($user, $message) {
+        $cususervars = $this->get_user_custom_values($user);
+        $defuservars = $this->get_user_default_values($user);
+
+        foreach ($this->defaultfields as $field) {
+            $message = str_replace('[['.$field.']]', $defuservars[$field], $message);
+        }
+
+        foreach ($this->customfields as $field) {
+            $message = str_replace('[['.$field.']]', $cususervars[$field], $message);
+        }
+
+        foreach ($this->welcomefields as $field) {
+            $message = str_replace('[['.$field.']]', $this->welcomevalues[$field], $message);
+        }
+        return $message;
+
+    }
+}

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,87 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This plugin sends users a welcome message after logging in
+ * and notify a moderator a new user has been added
+ * it has a settings page that allow you to configure the messages
+ * send.
+ *
+ * @package    local
+ * @subpackage welcome
+ * @copyright  2015 Bas Brands, basbrands.nl, bas@sonsbeekmedia.nl
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_welcome;
+defined('MOODLE_INTERNAL') || die();
+
+class observer {
+
+    public static function send_welcome(\core\event\user_created $event) {
+        global $CFG, $SITE;
+
+        $user = \core_user::get_user($event->userid);
+
+        $sender = get_admin();
+
+        if (!empty($user->email)) {
+
+            $config = get_config('local_welcome');
+
+            $moderator = clone($sender);
+
+            if (!empty($config->auth_plugins)) {
+                $auths = explode(',', $config->auth_plugins);
+                if (!in_array($user->auth, $auths)) {
+                    return '';
+                }
+            } else {
+                return '';
+            }
+
+            $moderator->email = $config->moderator_email;
+
+            $sender->email = $config->sender_email;
+            $sender->firstname = $config->sender_firstname;
+            $sender->lastname = $config->sender_lastname;
+
+            $message_user_enabled = $config->message_user_enabled;
+            $message_user = $config->message_user;
+            $message_user_subject = $config->message_user_subject;
+
+            $message_moderator_enabled = $config->message_moderator_enabled;
+            $message_moderator = $config->message_moderator;
+            $message_moderator_subject = $config->message_moderator_subject;
+
+            $welcome = new local_welcome();
+
+            $message_user = $welcome->replace_values($user, $message_user);
+            $message_user_subject = $welcome->replace_values($user, $message_user_subject);
+            $message_moderator = $welcome->replace_values($user, $message_moderator);
+            $message_moderator_subject = $welcome->replace_values($user, $message_moderator_subject);
+
+            if (!empty($message_user) && !empty($sender->email) && $message_user_enabled) {
+                email_to_user($user, $sender, $message_user_subject, html_to_text($message_user), $message_user);
+            }
+
+            if (!empty($message_moderator) && !empty($sender->email) && $message_moderator_enabled) {
+                email_to_user($moderator, $sender, $message_moderator_subject, html_to_text($message_moderator), $message_moderator);
+            }
+        }
+    }
+
+}

--- a/db/events.php
+++ b/db/events.php
@@ -26,10 +26,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$handlers = array(
-    'user_created' => array (
-        'handlerfile'     => '/local/welcome/event_handlers.php',
-        'handlerfunction' => 'send_welcome',
-        'schedule'        => 'instant',
+$observers = array(
+    array(
+        'eventname' => '\core\event\user_created',
+        'callback' => '\local_welcome\observer::send_welcome',
     ),
 );

--- a/index.php
+++ b/index.php
@@ -27,7 +27,6 @@
  */
 
 require_once '../../config.php';
-require_once($CFG->dirroot . '/local/welcome/locallib.php');
 
 $context = context_system::instance();
 
@@ -35,7 +34,7 @@ require_login();
 if (!is_siteadmin()) {
     return '';
 }
-$welcome = new local_welcome();
+$welcome = new \local_welcome\message();
 
 $PAGE->set_context($context);
 $PAGE->set_url('/local/welcome/index.php.php');

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version  = 2015110300;
+$plugin->version  = 2015110303;
 $plugin->requires = 2012120300;
 $plugin->release = '1.2';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi Bas,

We are using this beautiful plugin for a long time now, and have change it slightly, but nothing that can interest the community, except...

While migrating to Moodle 3.1, we changed the Events 1 API (libraries) to Events 2 API (classes)
I tried to take off all the code that was specific to what changed for our internal needs and kept the generic code that has to do with the API change.

After taking all the redundant code, I haven't tested it, but I think it works fine.

Please review it and see if you can integrate.

Thank you very much for this beautiful plugin!
Nadav
