### PR TITLE
Fix case where get_admin returns false in unit tests

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -41,6 +41,11 @@ class observer {
 
         $sender = get_admin();
 
+        // Sender can be false when unit tests are running.
+        if ($sender === false) {
+            return;
+        }
+
         if (!empty($user->email)) {
 
             $config = get_config('local_welcome');


### PR DESCRIPTION
The function get_admin returns false during unit tests, and as observer reacts to events during unit test runs it can cause errors.